### PR TITLE
Fix UUID IFTTT

### DIFF
--- a/core/php/googlecast.iftt.php
+++ b/core/php/googlecast.iftt.php
@@ -38,7 +38,11 @@ try {
     $content = file_get_contents('php://input');
     $json = json_decode($content, true);
 
-    $googlecast = googlecast::byLogicalId($uuid);
+    if ( isset($queryparams['id']) ) {
+        $uuid=$queryparams['id'];
+    }
+    
+    $googlecast = googlecast::byLogicalId($uuid,'googlecast');
     if (!is_object($googlecast)) {
     	echo json_encode(array('text' => __('UUID inconnu : ', __FILE__) . $uuid));
     	die();


### PR DESCRIPTION
Le UUID n'était pas récupéré depuis l'url d'appel.

Ce fix permet de faire fonctionner les Interactions depuis IFTTT, exemple d'url à fournir à IFTTT :

http://#VOTRE_DNS#/plugins/googlecast/core/php/googlecast.iftt.php?apikey=#API_KEY_GCAST#&id=#ID_LOGIQUE_GCAST#&query= <<{{TextField}}>>