### PR TITLE
Pas besoin de faire une URL quote pour du SSML avec text.synthesize

### DIFF
--- a/resources/googlecast.py
+++ b/resources/googlecast.py
@@ -1483,7 +1483,6 @@ def get_tts_data(text, language, engine, speed, forcetts, calcduration, silence=
                     if 'usessml' in ttsparams :
                         ttsformat = 'ssml'
                         ttstext = ttstext.replace('^', '=')
-                        ttstext = urllib.parse.quote_plus(ttstext)
                 success=True
                 try:
                     gctts = gcloudTTS(globals.tts_gapi_key)


### PR DESCRIPTION
En passant a la nouvelle version du plugin, mes messages SSML n'etaient plus lus correctement. Par exemple le message d'exemple de la doc "<speak>Etape 1<break time^3s/>Etape 2</speak>" etait lu litteralement comme "%3Cspeak%3EEtape+1%3Cbreak+time%3D3s%2F%3EEtape+2%3C%2Fspeak%3E" (i.e la voix dit bien "pour cent trois C speak pour cent ..").
Avec cette correction les messages passent.