### PR TITLE
replaces status_text = "& nbsp;" by "No Media"

### DIFF
--- a/core/class/googlecast.class.php
+++ b/core/class/googlecast.class.php
@@ -966,7 +966,7 @@ class googlecast extends eqLogic
         $cmd .= ' --ttsdefaultsilenceduration ' . config::byKey('tts_default_silence_duration', 'googlecast', '300');
         $cmd .= ' --daemonname local';
         $cmd .= ' --cyclefactor ' . config::byKey('cyclefactor', 'googlecast', '1');
-        $cmd .= ' --defaultstatus ' . "'". config::byKey('defaultsatus', 'googlecast', "&nbsp;") ."'";
+        $cmd .= ' --defaultstatus ' . "'". config::byKey('defaultsatus', 'googlecast', "No Media") ."'";
         log::add('googlecast', 'info', 'Lancement démon googlecast : ' . $cmd);
         $result = exec($cmd . ' >> ' . log::getPathToLog('googlecast_local') . ' 2>&1 &');
         $i = 0;

--- a/docs/en_US/index.md
+++ b/docs/en_US/index.md
@@ -177,7 +177,7 @@ To see them on the dashboard, you have to activate 'Show' in the commands tab.
 > 'CMD UNKNOWN' if the command does not exist,
 > 'NOT CONNECTED' if offline or
 > 'ERROR' for other errors
-> - At rest (no action in progress), *status_text* = `& nbsp;`
+> - At rest (no action in progress), *status_text* = `No Media`
 
 
 ### Afficheur Lecture en cours (widget)

--- a/docs/fr_FR/index.md
+++ b/docs/fr_FR/index.md
@@ -197,7 +197,7 @@ Pour les voir sur le dashboard, il faut activer 'Afficher' dans l'onglet des com
 >   'CMD UNKNOWN' si la commande n'existe pas,
 >   'NOT CONNECTED' si offline ou
 >   'ERROR' pour les autres erreurs
-> - Au repos (pas d'action en cours), _status_text_ = `&nbsp;`
+> - Au repos (pas d'action en cours), _status_text_ = `No Media`
 
 ### Afficheur Lecture en cours (widget)
 


### PR DESCRIPTION
replaces status_text = "& nbsp;" by status_text = "No Media" because it is not possible to test on "& nbsp;" which is interpreted on the server side.
It is possible to do it in code block but this does not trigger a scenario for example.

utf8_encode (html_entity_decode (cmd :: byId (7586) -> execCmd ())) === utf8_encode (html_entity_decode (''))? cmd :: byId (7586) -> event (("No Media")): null;